### PR TITLE
Fix Windows build: exclude CZlib where system zlib is absent

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,12 @@ var products: [Product] = [
 ]
 
 var targets: [Target] = [
-    // Thin C wrapper exposing system zlib to Swift.
-    // zlib is present on macOS (SDK) and Linux (Swift toolchain dependency).
+    // Thin C wrapper exposing system zlib to Swift. The dependency below is gated to the
+    // platforms we build for and know ship zlib (macOS SDK, Linux toolchain). A platform
+    // condition is evaluated against the build *destination*, so this stays correct under
+    // cross-compilation — unlike a manifest `#if os(...)`, which keys off the host. On
+    // any other destination (Windows, wasm) CZlib drops out of the graph and the
+    // `#if canImport(CZlib)`-guarded MCCP compression compiles out.
     .target(
         name: "CZlib",
         path: "Sources/CZlib",
@@ -20,7 +24,7 @@ var targets: [Target] = [
     .target(
         name: "MTHCore",
         dependencies: [
-            "CZlib",
+            .target(name: "CZlib", condition: .when(platforms: [.macOS, .linux])),
         ],
         path: "Sources/SwiftMTHCore"
     ),


### PR DESCRIPTION
The `build (windows-latest)` CI job has been failing (pre-existing — also red on trunk) with:

```
Sources/CZlib/include/CZlib.h:4:10: fatal error: 'zlib.h' file not found
```

zlib ships with the macOS SDK and the Linux Swift toolchain but not on Windows, so the `CZlib` wrapper can't compile there.

The `MTHCore → CZlib` dependency is now gated with `.when(platforms: [.macOS, .linux])`. A platform condition is evaluated against the build **destination**, so this is also correct under cross-compilation — unlike a manifest `#if os(Windows)`, which keys off the host that evaluates the manifest (it would pull CZlib into a cross-compile *to* Windows, and drop it from a cross-compile *from* Windows to Linux). On any non-listed destination, CZlib drops out of the build graph and the `#if canImport(CZlib)`-guarded MCCP compression compiles out; macOS/Linux are unchanged.

Manifest only — no source changes.

Note: the sibling `Cmth`/`CmthColor` C-oracle targets still use a host-based `#if !os(Windows)` block. That has the same host-vs-destination limitation, but those are entangled with their product declarations and are C targets that can't build on Windows at all, so converting them is a separate change; the native Windows CI runner is unaffected.