### PR TITLE
MXP negotiation parity: C, Kotlin, and Swift client

### DIFF
--- a/Sources/SwiftMTHClient/TelnetClientSession.swift
+++ b/Sources/SwiftMTHClient/TelnetClientSession.swift
@@ -24,6 +24,7 @@ public final class TelnetClientSession {
     public private(set) var gmcpEnabled: Bool = false
     public private(set) var msdpEnabled: Bool = false
     public private(set) var msspEnabled: Bool = false
+    public private(set) var mxpEnabled: Bool = false
 
     // MARK: - Private State
 
@@ -188,6 +189,10 @@ public final class TelnetClientSession {
             TeloptPattern(pattern: [TC.IAC, TC.SB, TO.GMCP],
                           handler: { s, src, i, n in s.processSbGmcp(src, at: i, srclen: n) }),
 
+            // MXP — accept the server's offer so it may send MXP markup.
+            TeloptPattern(pattern: [TC.IAC, TC.WILL, TO.MXP],
+                          handler: { s, _, _, _ in s.processWillMxp(); return 3 }),
+
             // MSDP
             TeloptPattern(pattern: [TC.IAC, TC.WILL, TO.MSDP],
                           handler: { s, _, _, _ in s.processWillMsdp(); return 3 }),
@@ -312,6 +317,14 @@ public final class TelnetClientSession {
         serverOptions.insert(TO.GMCP)
         write([TC.IAC, TC.DO, TO.GMCP])
         delegate?.onGMCPNegotiated()
+    }
+
+    // MARK: - Handler: MXP
+
+    private func processWillMxp() {
+        mxpEnabled = true
+        serverOptions.insert(TO.MXP)
+        write([TC.IAC, TC.DO, TO.MXP])
     }
 
     private func processSbGmcp(_ src: [UInt8], at offset: Int, srclen: Int) -> Int {

--- a/Sources/cmth/mth.c
+++ b/Sources/cmth/mth.c
@@ -180,7 +180,7 @@ struct telnet_type telnet_table[] =
 	{    "88",                    0 },
 	{    "89",                    0 },
 	{    "MSP",                   0 },
-	{    "MXP",                   0 },
+	{    "MXP",                   ANNOUNCE_WILL },
 	{    "MSP2",                  0 }, /* Unadopted */
 	{    "ZMP",                   0 }, /* Unadopted */
 	{    "94",                    0 },

--- a/Sources/cmth/mth.h
+++ b/Sources/cmth/mth.h
@@ -62,6 +62,7 @@ typedef struct descriptor_data    DESCRIPTOR_DATA;
 #define COMM_FLAG_256COLORS     BV06
 #define COMM_FLAG_UTF8          BV07
 #define COMM_FLAG_GMCP          BV08
+#define COMM_FLAG_MXP           BV09
 
 #define MSDP_FLAG_COMMAND       BV01
 #define MSDP_FLAG_LIST          BV02

--- a/Sources/cmth/telopt.c
+++ b/Sources/cmth/telopt.c
@@ -21,6 +21,8 @@ int         process_do_msdp          ( DESCRIPTOR_DATA *d, unsigned char *src, i
 int         process_sb_msdp          ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
 int         process_do_gmcp          ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
 int         process_sb_gmcp          ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
+int         process_do_mxp           ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
+int         process_dont_mxp         ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
 int         process_do_mccp2         ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
 int         process_dont_mccp2       ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
 int         skip_sb                  ( DESCRIPTOR_DATA *d, unsigned char *src, int srclen );
@@ -66,6 +68,9 @@ const struct telopt_type telopt_table [] =
 
 	{ 3, (unsigned char []) { IAC, DO,   TELOPT_GMCP, 0 },                      &process_do_gmcp},
 	{ 3, (unsigned char []) { IAC, SB,   TELOPT_GMCP, 0 },                      &process_sb_gmcp},
+
+	{ 3, (unsigned char []) { IAC, DO,   TELOPT_MXP, 0 },                       &process_do_mxp},
+	{ 3, (unsigned char []) { IAC, DONT, TELOPT_MXP, 0 },                       &process_dont_mxp},
 
 	{ 3, (unsigned char []) { IAC, DO,   TELOPT_MCCP2, 0 },                     &process_do_mccp2},
 	{ 3, (unsigned char []) { IAC, DONT, TELOPT_MCCP2, 0 },                     &process_dont_mccp2},
@@ -861,6 +866,32 @@ int process_sb_msdp( DESCRIPTOR_DATA *d, unsigned char *src, int srclen )
 		}
 	}
 	return i + 1;
+}
+
+// MXP
+
+int process_do_mxp( DESCRIPTOR_DATA *d, unsigned char *src, int srclen )
+{
+	if (HAS_BIT(d->mth->comm_flags, COMM_FLAG_MXP))
+	{
+		return 3;
+	}
+
+	SET_BIT(d->mth->comm_flags, COMM_FLAG_MXP);
+
+	/* ESC[7z — Lock Locked: make "locked" the persistent default line mode, so
+	   normal output is never parsed as MXP markup. Links opt back in per-span. */
+	descriptor_printf(d, "\033[7z");
+	log_descriptor_printf(d, "INFO MXP ENABLED");
+
+	return 3;
+}
+
+int process_dont_mxp( DESCRIPTOR_DATA *d, unsigned char *src, int srclen )
+{
+	DEL_BIT(d->mth->comm_flags, COMM_FLAG_MXP);
+
+	return 3;
 }
 
 // MSDP over GMCP

--- a/Tests/MTHTests/TelnetClientSessionTests.swift
+++ b/Tests/MTHTests/TelnetClientSessionTests.swift
@@ -57,6 +57,14 @@ struct TelnetClientSessionTests {
         #expect(out == input)
     }
 
+    @Test func mxpWillIsAcceptedWithDo() {
+        let (s, d) = makeSession()
+        #expect(!s.mxpEnabled)
+        _ = s.processInput([TC.IAC, TC.WILL, TO.MXP])
+        #expect(s.mxpEnabled)
+        #expect(d.allWrittenBytes.containsSequence([TC.IAC, TC.DO, TO.MXP]))
+    }
+
     @Test func emptyInput() {
         let (s, _) = makeSession()
         let out = s.processInput([])

--- a/kotlin/mth-core/src/main/kotlin/mth/core/AnnounceFlags.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/AnnounceFlags.kt
@@ -32,6 +32,6 @@ val defaultTelnetTable: List<TelnetOptionEntry> = buildList {
     this[86] = TelnetOptionEntry("MCCP2", AnnounceFlags.WILL)
     this[87] = TelnetOptionEntry("MCCP3", AnnounceFlags.WILL)
     this[90] = TelnetOptionEntry("MSP", AnnounceFlags.WILL)
-    this[91] = TelnetOptionEntry("MXP")
+    this[91] = TelnetOptionEntry("MXP", AnnounceFlags.WILL)
     this[201] = TelnetOptionEntry("GMCP", AnnounceFlags.WILL)
 }

--- a/kotlin/mth-core/src/main/kotlin/mth/core/CommFlags.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/CommFlags.kt
@@ -16,5 +16,6 @@ value class CommFlags(val rawValue: Int = 0) {
         val COLORS_256 = CommFlags(1 shl 5)
         val UTF8 = CommFlags(1 shl 6)
         val GMCP = CommFlags(1 shl 7)
+        val MXP = CommFlags(1 shl 8)
     }
 }

--- a/kotlin/mth-core/src/main/kotlin/mth/core/client/TelnetClientSession.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/client/TelnetClientSession.kt
@@ -39,6 +39,10 @@ class TelnetClientSession(
     var msspEnabled: Boolean = false
         private set
 
+    /** Whether MXP has been negotiated. */
+    var mxpEnabled: Boolean = false
+        private set
+
     // -- Private State --
 
     /** Buffer for incomplete telnet sequences (packet fragmentation). */
@@ -230,6 +234,10 @@ class TelnetClientSession(
             TeloptPattern(byteArrayOf(TC.IAC, TC.SB, TO.GMCP))
                 { s, src, i, n -> s.processSbGmcp(src, i, n) },
 
+            // Server offers MXP — accept so it may send MXP markup.
+            TeloptPattern(byteArrayOf(TC.IAC, TC.WILL, TO.MXP))
+                { s, _, _, _ -> s.processWillMxp(); 3 },
+
             // Server offers MCCP2
             TeloptPattern(byteArrayOf(TC.IAC, TC.WILL, TO.MCCP2))
                 { s, _, _, _ -> s.processWillMccp2(); 3 },
@@ -344,6 +352,12 @@ class TelnetClientSession(
         serverOptions.add(TO.GMCP)
         write(byteArrayOf(TC.IAC, TC.DO, TO.GMCP))
         delegate?.onGMCPNegotiated()
+    }
+
+    private fun processWillMxp() {
+        mxpEnabled = true
+        serverOptions.add(TO.MXP)
+        write(byteArrayOf(TC.IAC, TC.DO, TO.MXP))
     }
 
     private fun processSbGmcp(src: ByteArray, offset: Int, srclen: Int): Int {

--- a/kotlin/mth-core/src/main/kotlin/mth/core/server/TelnetSession.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/server/TelnetSession.kt
@@ -113,6 +113,14 @@ class TelnetSession(
         write(byteArrayOf(TC.IAC, TC.WILL, TO.GMCP))
     }
 
+    /** Whether the client negotiated MXP (telnet option 91). */
+    val mxpEnabled: Boolean get() = CommFlags.MXP in commFlags
+
+    /** Re-assert the locked-default MXP line mode after a copyover restore. */
+    fun reassertMXP() {
+        if (CommFlags.MXP in commFlags) write(MXP_LOCKED_DEFAULT)
+    }
+
     /** Send echo-off (password mode). */
     fun sendEchoOff() {
         commFlags = commFlags.insert(CommFlags.PASSWORD)
@@ -341,6 +349,11 @@ class TelnetSession(
                 { s, _, _, _ -> s.processDoGmcp(); 3 },
             TeloptPattern(byteArrayOf(TC.IAC, TC.SB, TO.GMCP))
                 { s, src, i, n -> s.processSbGmcp(src, i, n) },
+
+            TeloptPattern(byteArrayOf(TC.IAC, TC.DO, TO.MXP))
+                { s, _, _, _ -> s.processDoMxp(); 3 },
+            TeloptPattern(byteArrayOf(TC.IAC, TC.DONT, TO.MXP))
+                { s, _, _, _ -> s.processDontMxp(); 3 },
 
             // MCCP2
             TeloptPattern(byteArrayOf(TC.IAC, TC.DO, TO.MCCP2))
@@ -728,6 +741,19 @@ class TelnetSession(
         return sbLen
     }
 
+    // -- Handler: MXP --
+
+    private fun processDoMxp() {
+        if (CommFlags.MXP in commFlags) return
+        commFlags = commFlags.insert(CommFlags.MXP)
+        write(MXP_LOCKED_DEFAULT)
+        log("INFO MXP ENABLED")
+    }
+
+    private fun processDontMxp() {
+        commFlags = commFlags.remove(CommFlags.MXP)
+    }
+
     // -- Handler: GMCP --
 
     private fun processDoGmcp() {
@@ -856,5 +882,11 @@ class TelnetSession(
         if (mccp3 == null) return
         log("MCCP3: COMPRESSION END")
         mccp3 = null
+    }
+
+    private companion object {
+        // ESC[7z — Lock Locked: makes "locked" the persistent default line mode so normal
+        // output is never parsed as MXP markup; links opt back in per-span with ESC[1z…ESC[2z.
+        val MXP_LOCKED_DEFAULT = byteArrayOf(0x1B, 0x5B, 0x37, 0x7A)
     }
 }

--- a/kotlin/mth-core/src/test/kotlin/mth/core/client/TelnetClientSessionTest.kt
+++ b/kotlin/mth-core/src/test/kotlin/mth/core/client/TelnetClientSessionTest.kt
@@ -124,6 +124,14 @@ class TelnetClientSessionTest {
         assertContentEquals(byteArrayOf(IAC, DO, GMCP), d.allWrittenBytes)
     }
 
+    @Test fun serverWillMxpRespondsDoMxp() {
+        val (s, d) = makeSession()
+        assertFalse(s.mxpEnabled)
+        s.processInput(bytes(0xFF, 0xFB, 91))
+        assertTrue(s.mxpEnabled)
+        assertContentEquals(bytes(0xFF, 0xFD, 91), d.allWrittenBytes)
+    }
+
     @Test fun serverSendsGmcpDataParsed() {
         val (s, d) = makeSession()
         s.processInput(byteArrayOf(IAC, WILL, GMCP))

--- a/kotlin/mth-core/src/test/kotlin/mth/core/server/TelnetSessionTest.kt
+++ b/kotlin/mth-core/src/test/kotlin/mth/core/server/TelnetSessionTest.kt
@@ -99,6 +99,30 @@ class TelnetSessionTest {
         assertTrue(out.isEmpty())
     }
 
+    // -- MXP --
+
+    @Test fun announcesWillMxp() {
+        val (s, d) = makeSession()
+        s.announceSupport()
+        assertTrue(d.allWrittenBytes.containsSequence(bytes(0xFF, 0xFB, 91)))
+    }
+
+    @Test fun doMxpEnablesAndLocksDefault() {
+        val (s, d) = makeSession()
+        assertFalse(s.mxpEnabled)
+        s.processInput(bytes(0xFF, 0xFD, 91))
+        assertTrue(s.mxpEnabled)
+        assertTrue(d.allWrittenBytes.containsSequence(bytes(0x1B, 0x5B, 0x37, 0x7A)))
+    }
+
+    @Test fun dontMxpDisables() {
+        val (s, _) = makeSession()
+        s.processInput(bytes(0xFF, 0xFD, 91))
+        assertTrue(s.mxpEnabled)
+        s.processInput(bytes(0xFF, 0xFE, 91))
+        assertFalse(s.mxpEnabled)
+    }
+
     // -- CR/NUL Handling --
 
     @Test fun crNulConvertsToNewline() {


### PR DESCRIPTION
The Swift **server** gained MXP negotiation (option 91) earlier; this adds it to the rest.

| Implementation | Change |
|---|---|
| **C** (`cmth`) | `COMM_FLAG_MXP` (BV09); `telnet_table[91]` → `ANNOUNCE_WILL`; `process_do_mxp` (set flag, emit `ESC[7z` locked default) + `process_dont_mxp`, wired into `negotiation_table` |
| **Kotlin server** (`mth-core/server`) | `CommFlags.MXP` (`1 shl 8`); table[91] → `AnnounceFlags.WILL`; `processDoMxp`/`processDontMxp` + dispatch; `mxpEnabled` / `reassertMXP()` |
| **Kotlin client** (`mth-core/client`) | responds to `WILL MXP` with `DO MXP`; `mxpEnabled` |
| **Swift client** (`SwiftMTHClient`) | responds to `WILL MXP` with `DO MXP`; `mxpEnabled` |

Server side announces `WILL MXP`, handles the client's `DO/DONT`, and on enable emits `ESC[7z` (Lock Locked) so normal output is never parsed as markup — matching the Swift server. Client side accepts the server's `WILL` with `DO` and tracks the flag (tag *rendering* remains the client app's job).

## Tests
- Swift client: `mxpWillIsAcceptedWithDo` (feeding `WILL MXP` sets `mxpEnabled` + writes `DO MXP`).
- Kotlin server: announce `WILL MXP`, `DO`→enabled+`ESC[7z`, `DONT`→disabled.
- Kotlin client: `WILL MXP`→`DO MXP`+enabled.
- Swift `swift test` (155) and Kotlin `:mth-core:test` both green; C compiles via `swift build`.