### PR TITLE
Add MNES, MSLP, and SSL MTTS capability flags

### DIFF
--- a/Sources/SwiftMTHCore/MTTSFlags.swift
+++ b/Sources/SwiftMTHCore/MTTSFlags.swift
@@ -18,4 +18,7 @@ public struct MTTSFlags: OptionSet, Sendable {
     public static let screenReader   = MTTSFlags(rawValue: 1 << 6)
     public static let proxy          = MTTSFlags(rawValue: 1 << 7)
     public static let trueColor      = MTTSFlags(rawValue: 1 << 8)
+    public static let mnes           = MTTSFlags(rawValue: 1 << 9)
+    public static let mslp           = MTTSFlags(rawValue: 1 << 10)
+    public static let ssl            = MTTSFlags(rawValue: 1 << 11)
 }

--- a/Sources/cmth/mth.h
+++ b/Sources/cmth/mth.h
@@ -53,6 +53,8 @@ typedef struct descriptor_data    DESCRIPTOR_DATA;
 #define BV08            (1   <<  7)
 #define BV09            (1   <<  8)
 #define BV10            (1   <<  9)
+#define BV11            (1   <<  10)
+#define BV12            (1   <<  11)
 
 #define COMM_FLAG_DISCONNECT    BV01
 #define COMM_FLAG_PASSWORD      BV02
@@ -83,6 +85,9 @@ typedef struct descriptor_data    DESCRIPTOR_DATA;
 #define MTTS_FLAG_SCREENREADER  BV07
 #define MTTS_FLAG_PROXY         BV08
 #define MTTS_FLAG_TRUECOLOR     BV09
+#define MTTS_FLAG_MNES          BV10
+#define MTTS_FLAG_MSLP          BV11
+#define MTTS_FLAG_SSL           BV12
 
 /*
 	Mud data, structure containing global variables.

--- a/Tests/MTHTests/TelnetSessionTests.swift
+++ b/Tests/MTHTests/TelnetSessionTests.swift
@@ -353,6 +353,20 @@ private func makeSession() -> (TelnetSession, FakeDelegate) {
     #expect(s.mttsFlags.contains(.colors256))
     #expect(s.commFlags.contains(.colors256))
     #expect(s.commFlags.contains(.utf8))
+    // No MSLP bit in this bitvector.
+    #expect(!s.mttsFlags.contains(.mslp))
+}
+
+@Test func sbTtypeIsMTTSDetectsMSLP() {
+    let (s, _) = makeSession()
+    let first: [UInt8] = [IAC, SB, TTYPE, ENV_IS] + Array("TINTIN++".utf8) + [IAC, SE]
+    _ = s.processInput(first)
+
+    // ANSI(1) + VT100(2) + UTF8(4) + 256COLOR(8) + MSLP(1024) = 1039
+    let mtts: [UInt8] = [IAC, SB, TTYPE, ENV_IS] + Array("MTTS 1039".utf8) + [IAC, SE]
+    _ = s.processInput(mtts)
+
+    #expect(s.mttsFlags.contains(.mslp))
 }
 
 @Test func sbTtypeIsXtermSets256Color() {

--- a/kotlin/mth-core/src/main/kotlin/mth/core/MTTSFlags.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/MTTSFlags.kt
@@ -14,5 +14,8 @@ value class MTTSFlags(val rawValue: Int = 0) {
         val SCREEN_READER = MTTSFlags(1 shl 6)
         val PROXY = MTTSFlags(1 shl 7)
         val TRUE_COLOR = MTTSFlags(1 shl 8)
+        val MNES = MTTSFlags(1 shl 9)
+        val MSLP = MTTSFlags(1 shl 10)
+        val SSL = MTTSFlags(1 shl 11)
     }
 }


### PR DESCRIPTION
## What

Adds named `MTTSFlags` constants for three MTTS capability bits that were previously stored in the raw bitvector but had no named accessor:

- `MNES` — bit 512 (`1 << 9`)
- `MSLP` — bit 1024 (`1 << 10`)
- `SSL` — bit 2048 (`1 << 11`)

Added across all three implementations for parity:

- **Swift** — `Sources/SwiftMTHCore/MTTSFlags.swift`
- **C** — `Sources/cmth/mth.h` (`MTTS_FLAG_MNES/MSLP/SSL`, plus new `BV11`/`BV12` macros)
- **Kotlin** — `kotlin/mth-core/.../MTTSFlags.kt`

## Why

The MTTS integer was already parsed and stored whole (`TelnetSession.processSbTtypeIs`), but the higher capability bits lacked names. The immediate driver is MSLP (Mud Server Link Protocol) support in the ncmud server, which detects clients via MTTS bit 1024.

## Behavior

No runtime change. The raw MTTS value was always retained; these constants only add `.contains(...)` queries for bits that were already present. No existing code path reads the new bits.

## Tests

`Tests/MTHTests/TelnetSessionTests.swift`: new `sbTtypeIsMTTSDetectsMSLP` (parses `MTTS 1039` = ANSI+VT100+UTF8+256+MSLP and asserts the MSLP bit), plus a negative assertion on the existing MTTS test. `swift test` passes.
