### PR TITLE
Send the MXP start command so strict clients like MUSHclient activate MXP.

### DIFF
--- a/Sources/SwiftMTH/TelnetSession.swift
+++ b/Sources/SwiftMTH/TelnetSession.swift
@@ -162,10 +162,11 @@ public final class TelnetSession {
     /// Whether the client negotiated MXP (telnet option 91).
     public var mxpEnabled: Bool { commFlags.contains(.mxp) }
 
-    /// Re-assert the locked-default MXP line mode after a copyover restore, for a
-    /// client that had MXP enabled. See `processDoMxp`.
+    /// Re-assert MXP after a copyover restore, for a client that had MXP enabled:
+    /// resends the start command and the locked-default line mode. See `processDoMxp`.
     public func reassertMXP() {
         guard commFlags.contains(.mxp) else { return }
+        write(TelnetSession.mxpStart)
         write(TelnetSession.mxpLockedDefault)
     }
 
@@ -776,9 +777,15 @@ public final class TelnetSession {
     /// Links opt back in per-span with `ESC[1z … ESC[2z`. (Zugg MXP line-mode spec.)
     private static let mxpLockedDefault: [UInt8] = [0x1B, 0x5B, 0x37, 0x7A]
 
+    /// The MXP start command: tells the client to begin parsing MXP. WILL/DO only
+    /// agrees the option; strict clients stay inert until they receive this
+    /// subnegotiation.
+    private static let mxpStart: [UInt8] = [TC.IAC, TC.SB, TO.MXP, TC.IAC, TC.SE]
+
     private func processDoMxp() {
         guard !commFlags.contains(.mxp) else { return }
         commFlags.insert(.mxp)
+        write(TelnetSession.mxpStart)
         write(TelnetSession.mxpLockedDefault)
         log("INFO MXP ENABLED")
     }

--- a/Sources/cmth/telopt.c
+++ b/Sources/cmth/telopt.c
@@ -879,6 +879,10 @@ int process_do_mxp( DESCRIPTOR_DATA *d, unsigned char *src, int srclen )
 
 	SET_BIT(d->mth->comm_flags, COMM_FLAG_MXP);
 
+	/* The MXP start command: WILL/DO only agrees the option; strict clients
+	   stay inert until they receive this subnegotiation. */
+	descriptor_printf(d, "%c%c%c%c%c", IAC, SB, TELOPT_MXP, IAC, SE);
+
 	/* ESC[7z — Lock Locked: make "locked" the persistent default line mode, so
 	   normal output is never parsed as MXP markup. Links opt back in per-span. */
 	descriptor_printf(d, "\033[7z");

--- a/Tests/MTHTests/MXPNegotiationTests.swift
+++ b/Tests/MTHTests/MXPNegotiationTests.swift
@@ -6,10 +6,14 @@ private let IAC: UInt8 = 255
 private let DONT: UInt8 = 254
 private let DO: UInt8 = 253
 private let WILL: UInt8 = 251
+private let SB: UInt8 = 250
+private let SE: UInt8 = 240
 private let MXP: UInt8 = 91
 
 // ESC[7z — Lock Locked (persistent locked default line mode)
 private let lockedDefault: [UInt8] = [0x1B, 0x5B, 0x37, 0x7A]
+
+private let mxpStart: [UInt8] = [IAC, SB, MXP, IAC, SE]
 
 @Suite("MXP negotiation")
 struct MXPNegotiationTests {
@@ -29,6 +33,30 @@ struct MXPNegotiationTests {
         #expect(containsSubsequence(d.allBytes, lockedDefault))
     }
 
+    @Test func doMxpSendsStartCommandBeforeLockedDefault() {
+        let d = FakeDelegateMXP()
+        let s = TelnetSession(delegate: d)
+        _ = s.processInput([IAC, DO, MXP])
+        let bytes = d.allBytes
+        #expect(containsSubsequence(bytes, mxpStart))
+        // The start command must precede the line-mode escape: a client that is
+        // inert until the start command would otherwise miss the locked default.
+        if let startIndex = firstIndexOfSubsequence(bytes, mxpStart),
+           let lockIndex = firstIndexOfSubsequence(bytes, lockedDefault) {
+            #expect(startIndex < lockIndex)
+        }
+    }
+
+    @Test func reassertResendsStartCommandAndLockedDefault() {
+        let d = FakeDelegateMXP()
+        let s = TelnetSession(delegate: d)
+        _ = s.processInput([IAC, DO, MXP])
+        d.writtenChunks.removeAll()
+        s.reassertMXP()
+        #expect(containsSubsequence(d.allBytes, mxpStart))
+        #expect(containsSubsequence(d.allBytes, lockedDefault))
+    }
+
     @Test func dontMxpDisables() {
         let d = FakeDelegateMXP()
         let s = TelnetSession(delegate: d)
@@ -44,7 +72,8 @@ struct MXPNegotiationTests {
         _ = s.processInput([IAC, DO, MXP])
         d.writtenChunks.removeAll()
         _ = s.processInput([IAC, DO, MXP])
-        // Second DO MXP should not re-emit the locked-default marker.
+        // Second DO MXP should not re-emit the start command or locked-default marker.
+        #expect(!containsSubsequence(d.allBytes, mxpStart))
         #expect(!containsSubsequence(d.allBytes, lockedDefault))
     }
 
@@ -64,9 +93,13 @@ private final class FakeDelegateMXP: TelnetSessionDelegate {
 }
 
 private func containsSubsequence(_ haystack: [UInt8], _ needle: [UInt8]) -> Bool {
-    guard !needle.isEmpty, haystack.count >= needle.count else { return false }
+    firstIndexOfSubsequence(haystack, needle) != nil
+}
+
+private func firstIndexOfSubsequence(_ haystack: [UInt8], _ needle: [UInt8]) -> Int? {
+    guard !needle.isEmpty, haystack.count >= needle.count else { return nil }
     for start in 0...(haystack.count - needle.count) where Array(haystack[start..<start + needle.count]) == needle {
-        return true
+        return start
     }
-    return false
+    return nil
 }

--- a/kotlin/mth-core/src/main/kotlin/mth/core/server/TelnetSession.kt
+++ b/kotlin/mth-core/src/main/kotlin/mth/core/server/TelnetSession.kt
@@ -116,9 +116,13 @@ class TelnetSession(
     /** Whether the client negotiated MXP (telnet option 91). */
     val mxpEnabled: Boolean get() = CommFlags.MXP in commFlags
 
-    /** Re-assert the locked-default MXP line mode after a copyover restore. */
+    /** Re-assert MXP after a copyover restore: resends the start command and the
+     * locked-default line mode. */
     fun reassertMXP() {
-        if (CommFlags.MXP in commFlags) write(MXP_LOCKED_DEFAULT)
+        if (CommFlags.MXP in commFlags) {
+            write(MXP_START)
+            write(MXP_LOCKED_DEFAULT)
+        }
     }
 
     /** Send echo-off (password mode). */
@@ -746,6 +750,7 @@ class TelnetSession(
     private fun processDoMxp() {
         if (CommFlags.MXP in commFlags) return
         commFlags = commFlags.insert(CommFlags.MXP)
+        write(MXP_START)
         write(MXP_LOCKED_DEFAULT)
         log("INFO MXP ENABLED")
     }
@@ -888,5 +893,9 @@ class TelnetSession(
         // ESC[7z — Lock Locked: makes "locked" the persistent default line mode so normal
         // output is never parsed as MXP markup; links opt back in per-span with ESC[1z…ESC[2z.
         val MXP_LOCKED_DEFAULT = byteArrayOf(0x1B, 0x5B, 0x37, 0x7A)
+
+        // The MXP start command: WILL/DO only agrees the option; strict clients
+        // stay inert until they receive this subnegotiation.
+        val MXP_START = byteArrayOf(TC.IAC, TC.SB, TO.MXP, TC.IAC, TC.SE)
     }
 }

--- a/kotlin/mth-core/src/test/kotlin/mth/core/server/TelnetSessionTest.kt
+++ b/kotlin/mth-core/src/test/kotlin/mth/core/server/TelnetSessionTest.kt
@@ -33,6 +33,7 @@ private const val MSDP: Byte = 69
 private const val MSSP: Byte = 70
 private const val MCCP2: Byte = 86
 private const val MCCP3: Byte = 87
+private const val MXP: Byte = 91
 private const val GMCP: Byte = 0xC9.toByte()
 
 // Sub-negotiation constants
@@ -110,16 +111,22 @@ class TelnetSessionTest {
     @Test fun doMxpEnablesAndLocksDefault() {
         val (s, d) = makeSession()
         assertFalse(s.mxpEnabled)
-        s.processInput(bytes(0xFF, 0xFD, 91))
+        s.processInput(byteArrayOf(IAC, DO, MXP))
         assertTrue(s.mxpEnabled)
         assertTrue(d.allWrittenBytes.containsSequence(bytes(0x1B, 0x5B, 0x37, 0x7A)))
     }
 
+    @Test fun doMxpSendsStartCommand() {
+        val (s, d) = makeSession()
+        s.processInput(byteArrayOf(IAC, DO, MXP))
+        assertTrue(d.allWrittenBytes.containsSequence(byteArrayOf(IAC, SB, MXP, IAC, SE)))
+    }
+
     @Test fun dontMxpDisables() {
         val (s, _) = makeSession()
-        s.processInput(bytes(0xFF, 0xFD, 91))
+        s.processInput(byteArrayOf(IAC, DO, MXP))
         assertTrue(s.mxpEnabled)
-        s.processInput(bytes(0xFF, 0xFE, 91))
+        s.processInput(byteArrayOf(IAC, DONT, MXP))
         assertFalse(s.mxpEnabled)
     }
 


### PR DESCRIPTION
The server was treating the client's IAC DO MXP as full activation and immediately switching to escaped, tagged output, but the MXP handshake has a third step: after WILL/DO, the server must send the start command `IAC SB MXP IAC SE`. MUSHclient's default "Use MXP: on command" setting waits for exactly that subnegotiation before it turns its parser on, so it displayed everything literally. Mudlet-family clients activate on WILL/DO alone, which is why this never showed up in testing.

This sends the start command in `processDoMxp()` ahead of the `ESC[7z` locked-default line mode (a client that only starts parsing at the start command would otherwise miss the lock), and resends it from `reassertMXP()` on the copyover path. Same change mirrored into the C oracle and Kotlin implementations, with tests asserting the start command is sent, ordered before the lock, and not re-emitted on a duplicate DO.